### PR TITLE
style(requiresAuth.hook): Use injected service in place of manual `transition.injector()`

### DIFF
--- a/app/global/requiresAuth.hook.js
+++ b/app/global/requiresAuth.hook.js
@@ -16,7 +16,6 @@ export function authHookRunBlock($transitions, AuthService) {
   // if the user is not currently authenticated (according to the AuthService)
 
   let redirectToLogin = (transition) => {
-    let AuthService = transition.injector().get('AuthService');
     let $state = transition.router.stateService;
     if (!AuthService.isAuthenticated()) {
       return $state.target('login', undefined, { location: false });


### PR DESCRIPTION
Please discard the PR if `transition.injector()` was used intentionally for demonstratory purposes
